### PR TITLE
Revamp portfolio section with hover videos and filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,54 +197,91 @@
     <!-- ===========================
          WORK / PORTFOLIO (hover video previews)
          =========================== -->
-    <section id="work" class="ss-section ss-work" aria-labelledby="work-title" data-module="portfolioHover">
+    <section id="work" class="ss-section ss-work work" aria-labelledby="work-title" data-module="portfolioHover">
       <div class="container">
-        <header class="section-head" data-reveal>
-          <h2 id="work-title">Launch Files</h2>
-          <p class="lead">Three SwiftSend 2.0 builds proving speed, savings, and ownership.</p>
-        </header>
-
-        <div class="filters" role="tablist" aria-label="Portfolio filters" data-reveal>
-          <button role="tab" aria-selected="true" data-filter="all" class="pill" data-underline>All</button>
-          <button role="tab" aria-selected="false" data-filter="commerce" class="pill" data-underline>Commerce</button>
-          <button role="tab" aria-selected="false" data-filter="operations" class="pill" data-underline>Operations</button>
-          <button role="tab" aria-selected="false" data-filter="services" class="pill" data-underline>Services</button>
+        <div class="work__head" data-reveal>
+          <h2 id="work-title" class="work__title">Launch Files</h2>
+          <p class="lead work__sub">Four build sprints shipped for local founders — each pairing a payment-smart stack with ownable handoff docs.</p>
         </div>
 
-        <div class="work-grid" role="list">
-          <article class="work-card" role="listitem" data-tags="commerce services" data-reveal>
-            <div class="media">
-              <video muted preload="metadata" poster="./assets/img/nailtech-thumb.jpg" data-hover-video="./assets/video/nailtech-preview.webm"></video>
+        <div class="work__filters work-filter" role="tablist" aria-label="Portfolio filters" data-reveal>
+          <button type="button" role="tab" aria-selected="true" aria-controls="workGrid" data-filter="all" class="filter-chip" data-underline>All</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="workGrid" data-filter="realtor" class="filter-chip" data-underline>Realtor</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="workGrid" data-filter="beauty" class="filter-chip" data-underline>Beauty</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="workGrid" data-filter="creative" class="filter-chip" data-underline>Creative</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="workGrid" data-filter="smb" class="filter-chip" data-underline>SMB</button>
+        </div>
+
+        <div id="workGrid" class="work__grid work-grid" role="list" data-portfolio-grid>
+          <article class="work-card" role="listitem" data-tags="realtor smb" tabindex="0" data-reveal>
+            <div class="work-card__media">
+              <img src="./assets/img/realtor-thumb.jpg" alt="Realtor demo dashboard with featured listings" class="work-card__img" loading="lazy" />
+              <video class="work-card__video" muted preload="metadata" playsinline data-hover-src="./assets/video/realtor-preview.webm"></video>
+              <span class="work-card__play" aria-hidden="true">▶</span>
             </div>
-            <div class="meta">
-              <h3>GlowBar Express</h3>
-              <p class="tiny"><strong>Problem:</strong> Booking gaps and high card fees.</p>
-              <p class="tiny"><strong>Build:</strong> Mobile-first service menu, instant deposits, and bank-preferred checkout.</p>
-              <p class="tiny"><strong>Outcome:</strong> 28% lift in repeat bookings and $900/month in recovered margin.</p>
+            <div class="work-card__body">
+              <h3 class="work-card__title">RealtorDemo</h3>
+              <p class="work-card__meta tiny"><strong>Problem:</strong> Builder spec sheets and MLS blasts hitting spam folders.</p>
+              <p class="work-card__meta tiny"><strong>Build:</strong> React microsite system with instant listing sync, saved search alerts, and CRM hand-off.</p>
+              <p class="work-card__meta tiny"><strong>Outcome:</strong> 2.4&times; more referrals booked inside 30 days.</p>
+              <div class="work-card__tags" aria-label="Project categories">
+                <span class="work-tag">Realtor</span>
+                <span class="work-tag">SMB</span>
+              </div>
             </div>
           </article>
 
-          <article class="work-card" role="listitem" data-tags="operations" data-reveal>
-            <div class="media">
-              <video muted preload="metadata" poster="./assets/img/photo-thumb.jpg" data-hover-video="./assets/video/photo-preview.webm"></video>
+          <article class="work-card" role="listitem" data-tags="beauty smb" tabindex="0" data-reveal>
+            <div class="work-card__media">
+              <img src="./assets/img/nailtech-thumb.jpg" alt="Booking screen for NailTech Aamna" class="work-card__img" loading="lazy" />
+              <video class="work-card__video" muted preload="metadata" playsinline data-hover-src="./assets/video/nailtech-preview.webm"></video>
+              <span class="work-card__play" aria-hidden="true">▶</span>
             </div>
-            <div class="meta">
-              <h3>AtlasOps Dispatch</h3>
-              <p class="tiny"><strong>Problem:</strong> Field teams juggling spreadsheets.</p>
-              <p class="tiny"><strong>Build:</strong> Progressive web app with route planning, offline sync, and ops dashboards.</p>
-              <p class="tiny"><strong>Outcome:</strong> 3x faster job routing and same-day reporting.</p>
+            <div class="work-card__body">
+              <h3 class="work-card__title">NailTech Aamna</h3>
+              <p class="work-card__meta tiny"><strong>Problem:</strong> Booking gaps and high processor fees.</p>
+              <p class="work-card__meta tiny"><strong>Build:</strong> Mobile-first service menu with Express Checkout, deposit rules, and SMS confirmations.</p>
+              <p class="work-card__meta tiny"><strong>Outcome:</strong> 28% lift in repeat bookings and $900/month margin recovered.</p>
+              <div class="work-card__tags" aria-label="Project categories">
+                <span class="work-tag">Beauty</span>
+                <span class="work-tag">SMB</span>
+              </div>
             </div>
           </article>
 
-          <article class="work-card" role="listitem" data-tags="commerce services" data-reveal>
-            <div class="media">
-              <video muted preload="metadata" poster="./assets/img/realtor-thumb.jpg" data-hover-video="./assets/video/realtor-preview.webm"></video>
+          <article class="work-card" role="listitem" data-tags="creative smb" tabindex="0" data-reveal>
+            <div class="work-card__media">
+              <img src="./assets/img/photo-thumb.jpg" alt="Photographer portfolio landing page" class="work-card__img" loading="lazy" />
+              <video class="work-card__video" muted preload="metadata" playsinline data-hover-src="./assets/video/photo-preview.webm"></video>
+              <span class="work-card__play" aria-hidden="true">▶</span>
             </div>
-            <div class="meta">
-              <h3>PrimeAgent Hub</h3>
-              <p class="tiny"><strong>Problem:</strong> Template sites losing referral traffic.</p>
-              <p class="tiny"><strong>Build:</strong> Custom listing microsites, lead scoring, and CRM automations.</p>
-              <p class="tiny"><strong>Outcome:</strong> 41% more qualified leads in the first month.</p>
+            <div class="work-card__body">
+              <h3 class="work-card__title">Photographer Site</h3>
+              <p class="work-card__meta tiny"><strong>Problem:</strong> Gallery proofs scattered across Dropbox links.</p>
+              <p class="work-card__meta tiny"><strong>Build:</strong> Headless CMS with client proofing, Stripe paywalls, and automated delivery bundles.</p>
+              <p class="work-card__meta tiny"><strong>Outcome:</strong> 3x faster album approvals and upsells at checkout.</p>
+              <div class="work-card__tags" aria-label="Project categories">
+                <span class="work-tag">Creative</span>
+                <span class="work-tag">SMB</span>
+              </div>
+            </div>
+          </article>
+
+          <article class="work-card" role="listitem" data-tags="beauty smb" tabindex="0" data-reveal>
+            <div class="work-card__media">
+              <img src="./assets/img/barber-thumb.jpg" alt="Barber appointment dashboard" class="work-card__img" loading="lazy" />
+              <video class="work-card__video" muted preload="metadata" playsinline data-hover-src="./assets/video/barber-preview.webm"></video>
+              <span class="work-card__play" aria-hidden="true">▶</span>
+            </div>
+            <div class="work-card__body">
+              <h3 class="work-card__title">Barber Demo</h3>
+              <p class="work-card__meta tiny"><strong>Problem:</strong> Walk-ins waiting and no-show fades hurting loyalty.</p>
+              <p class="work-card__meta tiny"><strong>Build:</strong> Self-check kiosk with waitlist SMS, chair assignments, and loyalty wallet tied to ACH.</p>
+              <p class="work-card__meta tiny"><strong>Outcome:</strong> 35% faster turns and fee savings rerouted to client rewards.</p>
+              <div class="work-card__tags" aria-label="Project categories">
+                <span class="work-tag">Beauty</span>
+                <span class="work-tag">SMB</span>
+              </div>
             </div>
           </article>
         </div>

--- a/scripts/modules/portfolioHover.js
+++ b/scripts/modules/portfolioHover.js
@@ -1,46 +1,259 @@
 // /scripts/modules/portfolioHover.js
-// Work cards filtering + hover-play videos
+// Portfolio filters + hover/focus video previews with keyboard support.
 
 import { qs, qsa } from "../utils/dom.js";
 
-function handleFilterClick(e) {
-  const btn = e.currentTarget;
-  const category = btn.dataset.category;
+const FILTER_SELECTOR = ".work-filter [data-filter]";
+const CARD_SELECTOR = ".work-card";
+const GRID_SELECTOR = "[data-portfolio-grid]";
+const TRANSITION_FALLBACK_MS = 280;
 
-  // Toggle aria-pressed
-  qsa(".work-filter [aria-pressed]").forEach((b) =>
-    b.setAttribute("aria-pressed", "false")
-  );
-  btn.setAttribute("aria-pressed", "true");
+const cardControls = new WeakMap();
+const hideHandlers = new WeakMap();
+const hideTimers = new WeakMap();
+let heightResetTimer = null;
 
-  // Show/hide cards
-  qsa(".work-card").forEach((card) => {
-    const match = category === "all" || card.dataset.category === category;
-    card.classList.toggle("is-hidden", !match);
-  });
+function parseTags(card) {
+  return card.dataset.tags ? card.dataset.tags.split(/\s+/).filter(Boolean) : [];
+}
+
+function stopVideo(card, reset = false) {
+  const controls = cardControls.get(card);
+  if (!controls || typeof controls.pause !== "function") return;
+  controls.pause(reset);
 }
 
 function enableVideoHover(card) {
-  const video = card.querySelector("video");
-  if (!video) return;
+  const video = card.querySelector(".work-card__video");
+  if (!video) return null;
 
-  const play = () => {
-    video.play().catch(() => {});
+  const loadVideo = () => {
+    if (video.dataset.hoverLoaded === "true") return;
+    const src = video.dataset.hoverSrc || video.dataset.hoverVideo;
+    if (src && !video.src) {
+      video.src = src;
+      video.dataset.hoverLoaded = "true";
+    }
   };
-  const pause = () => video.pause();
 
-  card.addEventListener("mouseenter", play);
-  card.addEventListener("focusin", play);
-  card.addEventListener("mouseleave", pause);
-  card.addEventListener("focusout", pause);
+  const attemptPlay = () => {
+    loadVideo();
+    const playPromise = video.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch(() => {});
+    }
+  };
+
+  const pause = (resetTime = false) => {
+    video.pause();
+    if (resetTime) {
+      try {
+        video.currentTime = 0;
+      } catch (err) {
+        /* no-op */
+      }
+    }
+  };
+
+  const handleEnter = () => attemptPlay();
+  const handleLeave = () => pause(false);
+
+  card.addEventListener("mouseenter", handleEnter);
+  card.addEventListener("focusin", handleEnter);
+  card.addEventListener("mouseleave", handleLeave);
+  card.addEventListener("focusout", handleLeave);
+
+  return {
+    pause,
+  };
+}
+
+function lockGridHeight(grid) {
+  if (!grid) return () => {};
+  const currentHeight = grid.offsetHeight;
+  grid.style.minHeight = `${currentHeight}px`;
+  if (heightResetTimer) {
+    window.clearTimeout(heightResetTimer);
+  }
+  return () => {
+    heightResetTimer = window.setTimeout(() => {
+      grid.style.minHeight = "";
+    }, TRANSITION_FALLBACK_MS + 80);
+  };
+}
+
+function showCard(card) {
+  const pendingHandler = hideHandlers.get(card);
+  if (pendingHandler) {
+    card.removeEventListener("transitionend", pendingHandler);
+    hideHandlers.delete(card);
+  }
+
+  const pendingTimer = hideTimers.get(card);
+  if (pendingTimer) {
+    window.clearTimeout(pendingTimer);
+    hideTimers.delete(card);
+  }
+
+  card.classList.remove("is-hidden", "is-fading-out");
+  card.setAttribute("aria-hidden", "false");
+  card.tabIndex = 0;
+  card.classList.add("is-activating");
+  requestAnimationFrame(() => {
+    card.classList.remove("is-activating");
+  });
+}
+
+function hideCard(card) {
+  if (card.classList.contains("is-hidden")) return;
+  card.classList.add("is-fading-out");
+  card.setAttribute("aria-hidden", "true");
+  card.tabIndex = -1;
+  card.classList.remove("is-activating");
+
+  const finish = () => {
+    card.classList.add("is-hidden");
+    card.classList.remove("is-fading-out");
+    hideHandlers.delete(card);
+    const timer = hideTimers.get(card);
+    if (timer) {
+      window.clearTimeout(timer);
+      hideTimers.delete(card);
+    }
+  };
+
+  let completed = false;
+  const handle = (event) => {
+    if (event.propertyName !== "opacity") return;
+    completed = true;
+    card.removeEventListener("transitionend", handle);
+    finish();
+  };
+
+  card.addEventListener("transitionend", handle);
+  hideHandlers.set(card, handle);
+
+  const timeoutId = window.setTimeout(() => {
+    if (completed) return;
+    card.removeEventListener("transitionend", handle);
+    finish();
+  }, TRANSITION_FALLBACK_MS);
+  hideTimers.set(card, timeoutId);
+}
+
+function applyFilter(category, cards, grid) {
+  const releaseHeight = lockGridHeight(grid);
+  const activeFilter = category.toLowerCase();
+
+  cards.forEach((card) => {
+    const tags = parseTags(card);
+    const matches = activeFilter === "all" || tags.includes(activeFilter);
+    if (matches) {
+      showCard(card);
+    } else {
+      stopVideo(card, true);
+      hideCard(card);
+    }
+  });
+
+  releaseHeight();
+}
+
+function setActiveButton(activeBtn, buttons) {
+  buttons.forEach((btn) => {
+    const isActive = btn === activeBtn;
+    btn.setAttribute("aria-selected", isActive ? "true" : "false");
+    btn.classList.toggle("is-active", isActive);
+    btn.tabIndex = isActive ? 0 : -1;
+  });
+}
+
+function handleFilterKeydown(event, buttons) {
+  const { key } = event;
+  const currentIndex = buttons.indexOf(event.currentTarget);
+
+  if (key === "ArrowRight" || key === "ArrowDown") {
+    event.preventDefault();
+    const next = buttons[(currentIndex + 1) % buttons.length];
+    next.focus();
+    next.click();
+    return;
+  }
+
+  if (key === "ArrowLeft" || key === "ArrowUp") {
+    event.preventDefault();
+    const next = buttons[(currentIndex - 1 + buttons.length) % buttons.length];
+    next.focus();
+    next.click();
+    return;
+  }
+
+  if (key === "Home") {
+    event.preventDefault();
+    const first = buttons[0];
+    first.focus();
+    first.click();
+    return;
+  }
+
+  if (key === "End") {
+    event.preventDefault();
+    const last = buttons[buttons.length - 1];
+    last.focus();
+    last.click();
+    return;
+  }
+
+  if (key === " " || key === "Enter") {
+    event.preventDefault();
+    event.currentTarget.click();
+  }
 }
 
 export function initPortfolioHover() {
-  // Filter chips
-  qsa(".work-filter [data-category]").forEach((btn) =>
-    btn.addEventListener("click", handleFilterClick)
-  );
+  const buttons = Array.from(qsa(FILTER_SELECTOR));
+  const cards = Array.from(qsa(CARD_SELECTOR));
+  const grid = qs(GRID_SELECTOR);
 
-  // Hover-play videos
-  qsa(".work-card").forEach(enableVideoHover);
+  if (!cards.length) return;
+
+  cards.forEach((card) => {
+    if (!card.hasAttribute("tabindex")) {
+      card.tabIndex = 0;
+    }
+    card.setAttribute("aria-hidden", "false");
+    const controls = enableVideoHover(card);
+    if (controls) {
+      cardControls.set(card, controls);
+    }
+  });
+
+  if (!buttons.length) {
+    return;
+  }
+
+  buttons.forEach((btn) => {
+    if (!btn.hasAttribute("type")) {
+      btn.type = "button";
+    }
+    btn.tabIndex = btn.getAttribute("aria-selected") === "true" ? 0 : -1;
+    btn.addEventListener("click", () => {
+      setActiveButton(btn, buttons);
+      applyFilter(btn.dataset.filter || "all", cards, grid);
+    });
+    btn.addEventListener("keydown", (event) => handleFilterKeydown(event, buttons));
+  });
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      cards.forEach((card) => stopVideo(card, true));
+    }
+  });
+
+  // Ensure the initial filter state is applied to match the default aria-selected button.
+  const initiallyActive = buttons.find((btn) => btn.getAttribute("aria-selected") === "true") || buttons[0];
+  if (initiallyActive) {
+    setActiveButton(initiallyActive, buttons);
+    applyFilter(initiallyActive.dataset.filter || "all", cards, grid);
+  }
 }

--- a/styles/sections/work.css
+++ b/styles/sections/work.css
@@ -1,330 +1,293 @@
 /* =========================================
-   SwiftSendMax 1.0 — Work / Portfolio
-   Grid with hover-play videos + category filters
+   SwiftSend — Work / Portfolio Grid
+   Hover previews + filterable categories
    ========================================= */
 
-/* ---------- Vars (hooked to global tokens) ---------- */
-:root{
-    --ss-text: var(--color-text, #f5f7fb);
-    --ss-text-dim: var(--color-text-dim, #c9cfdb);
-    --ss-border: var(--color-border, rgba(255,255,255,0.12));
-    --ss-accent: var(--color-accent, #b14cff);
-    --ss-accent-2: var(--color-accent-2, #ff7a18);
-    --ss-surface: var(--color-surface, rgba(255,255,255,0.06));
-    --ss-blur: var(--blur-amount, 10px);
-    --ss-radius-xl: var(--radius-xl, 18px);
-    --ss-radius-lg: var(--radius-lg, 14px);
-    --ease-out: cubic-bezier(.17,.67,.28,.99);
-  
-    --work-cols: 3;
-    --work-gap: clamp(16px, 2.6vw, 28px);
-    --thumb-ratio: 9 / 6; /* widescreen-ish */
-  }
-  
-  /* ---------- Section shell ---------- */
-  .work{
-    position: relative;
-    color: var(--ss-text);
-    padding-block: clamp(28px, 7vh, 64px);
-    isolation: isolate;
-  }
-  
-  .work__head{
-    display: grid;
-    gap: 10px;
-    margin-bottom: clamp(16px, 2vh, 24px);
-  }
-  
-  .work__title{
-    font-size: clamp(1.8rem, 3.6vw, 2.4rem);
-    font-weight: 800;
-    letter-spacing: .2px;
-    line-height: 1.15;
-    text-wrap: balance;
-  }
-  
-  .work__sub{
-    color: var(--ss-text-dim);
-    max-width: 70ch;
-    line-height: 1.6;
-  }
-  
-  /* ---------- Filters (chips) ---------- */
-  .work__filters{
-    margin-top: clamp(10px, 1.6vh, 16px);
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-  
-  .filter-chip{
-    appearance: none;
-    -webkit-appearance: none;
-    border: 1px solid var(--ss-border);
-    background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-    -webkit-backdrop-filter: blur(var(--ss-blur));
-    backdrop-filter: blur(var(--ss-blur));
-    color: var(--ss-text);
-    padding: 8px 12px;
-    border-radius: 999px;
-    font-size: .92rem;
-    font-weight: 600;
-    letter-spacing: .2px;
-    cursor: pointer;
-    transition: transform .18s var(--ease-out), border-color .18s var(--ease-out), background .18s var(--ease-out), opacity .18s var(--ease-out);
-  }
-  .filter-chip:hover,
-  .filter-chip:focus-visible{ transform: translateY(-1px); border-color: rgba(255,255,255,.24); }
-  .filter-chip[aria-pressed="true"],
-  .filter-chip.is-active{
-    border-color: rgba(255,255,255,.32);
-    box-shadow: 0 0 0 1px rgba(255,255,255,.02) inset, 0 10px 26px rgba(0,0,0,.35);
-    background:
-      linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.03)),
-      radial-gradient(80% 80% at 50% 30%, rgba(177,76,255,.18), rgba(177,76,255,0));
-  }
-  
-  /* ---------- Grid ---------- */
-  .work__grid{
-    margin-top: clamp(18px, 3vh, 28px);
-    display: grid;
-    gap: var(--work-gap);
-    grid-template-columns: repeat(var(--work-cols), 1fr);
-  }
-  
-  @media (max-width: 1200px){
-    :root{ --work-cols: 3; }
-  }
-  @media (max-width: 1024px){
-    :root{ --work-cols: 2; }
-  }
-  @media (max-width: 560px){
-    :root{ --work-cols: 1; }
-  }
-  
-  /* ---------- Card ---------- */
-  .work-card{
-    position: relative;
-    display: grid;
-    grid-template-rows: auto 1fr;
-    gap: 10px;
-    border: 1px solid var(--ss-border);
-    border-radius: var(--ss-radius-xl);
-    overflow: hidden;
-    background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
-    -webkit-backdrop-filter: blur(var(--ss-blur));
-    backdrop-filter: blur(var(--ss-blur));
-    box-shadow: 0 12px 38px rgba(0,0,0,.38);
-    transition: transform .28s var(--ease-out), box-shadow .28s var(--ease-out), border-color .2s var(--ease-out);
-    will-change: transform, box-shadow;
-  }
-  
-  /* tiny hop + glow */
-  .work-card:where(:hover,:focus-within){
-    transform: translateY(-4px);
-    box-shadow: 0 16px 52px rgba(0,0,0,.46);
-    border-color: rgba(255,255,255,.22);
-  }
-  
-  /* ---------- Media (image + hover video) ---------- */
-  .work-card__media{
-    position: relative;
-    aspect-ratio: var(--thumb-ratio);
-    overflow: hidden;
-    background:
-      linear-gradient(180deg, rgba(0,0,0,.25), rgba(0,0,0,.4)),
-      radial-gradient(80% 60% at 50% 30%, rgba(177,76,255,.18), rgba(177,76,255,0));
-  }
-  
+:root {
+  --work-text: var(--color-text, #f5f7fb);
+  --work-text-dim: var(--color-text-dim, #c9cfdb);
+  --work-border: var(--color-border, rgba(255, 255, 255, 0.12));
+  --work-surface: rgba(255, 255, 255, 0.04);
+  --work-highlight: var(--color-accent, #d63cff);
+  --work-highlight-soft: var(--color-accent-2, #ff7a18);
+  --work-blur: var(--blur-amount, 12px);
+  --work-radius-xl: var(--radius-xl, 18px);
+  --work-radius-lg: var(--radius-lg, 14px);
+  --work-cols: 3;
+  --work-gap: clamp(18px, 2.6vw, 32px);
+  --work-ratio: 16 / 10;
+  --work-ease: cubic-bezier(0.17, 0.67, 0.28, 0.99);
+}
+
+.ss-work.work {
+  color: var(--work-text);
+  position: relative;
+  isolation: isolate;
+}
+
+.work__head {
+  display: grid;
+  gap: 12px;
+  margin-bottom: clamp(18px, 3vw, 26px);
+  text-align: center;
+}
+
+.work__title {
+  font-size: clamp(1.9rem, 3.8vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: 0.3px;
+}
+
+.work__sub {
+  color: var(--work-text-dim);
+  margin: 0 auto;
+  max-width: 70ch;
+}
+
+.work__filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: clamp(22px, 3vw, 32px);
+}
+
+.filter-chip {
+  appearance: none;
+  border: 1px solid var(--work-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  color: var(--work-text);
+  padding: 9px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.18px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.18s var(--work-ease), border-color 0.18s var(--work-ease), background 0.18s var(--work-ease), box-shadow 0.18s var(--work-ease), color 0.18s var(--work-ease);
+}
+
+.filter-chip:hover,
+.filter-chip:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.filter-chip[aria-selected="true"],
+.filter-chip.is-active {
+  border-color: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03)),
+    radial-gradient(80% 70% at 50% 15%, rgba(214, 60, 255, 0.22), rgba(214, 60, 255, 0));
+}
+
+.work__grid {
+  display: grid;
+  gap: var(--work-gap);
+  grid-template-columns: repeat(var(--work-cols), minmax(0, 1fr));
+  align-items: stretch;
+}
+
+@media (max-width: 1200px) {
+  :root { --work-cols: 3; }
+}
+
+@media (max-width: 1024px) {
+  :root { --work-cols: 2; }
+}
+
+@media (max-width: 620px) {
+  :root { --work-cols: 1; }
+  .work__head { text-align: left; }
+  .work__sub { margin-left: 0; }
+  .work__filters { justify-content: flex-start; }
+}
+
+.work-card {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  border-radius: var(--work-radius-xl);
+  border: 1px solid var(--work-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  backdrop-filter: blur(var(--work-blur));
+  -webkit-backdrop-filter: blur(var(--work-blur));
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
+  transition: transform 0.26s var(--work-ease), box-shadow 0.26s var(--work-ease), border-color 0.2s var(--work-ease), opacity 0.2s var(--work-ease);
+  outline: none;
+}
+
+.work-card:focus-visible {
+  box-shadow: 0 0 0 3px rgba(214, 60, 255, 0.45), 0 16px 44px rgba(0, 0, 0, 0.5);
+  border-color: rgba(214, 60, 255, 0.65);
+}
+
+.work-card:where(:hover, :focus-within) {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.5);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.work-card__media {
+  position: relative;
+  aspect-ratio: var(--work-ratio);
+  overflow: hidden;
+  border-radius: calc(var(--work-radius-xl) - 1px) calc(var(--work-radius-xl) - 1px) 0 0;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.45)),
+    radial-gradient(80% 70% at 50% 20%, rgba(214, 60, 255, 0.22), rgba(214, 60, 255, 0));
+}
+
+.work-card__img,
+.work-card__video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.work-card__img {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 0.28s var(--work-ease), transform 0.28s var(--work-ease);
+  will-change: opacity, transform;
+}
+
+.work-card__video {
+  opacity: 0;
+  transform: scale(1.02);
+  transition: opacity 0.28s var(--work-ease), transform 0.28s var(--work-ease);
+  filter: saturate(110%) contrast(105%);
+  background: transparent;
+}
+
+.work-card:where(:hover, :focus-within) .work-card__video {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.work-card:where(:hover, :focus-within) .work-card__img {
+  opacity: 0;
+  transform: scale(1.02);
+}
+
+.work-card__media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.4));
+  pointer-events: none;
+}
+
+.work-card__play {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 4;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.05));
+  color: var(--work-text);
+  font-size: 1.1rem;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: transform 0.22s var(--work-ease), opacity 0.22s var(--work-ease);
+  opacity: 0.85;
+}
+
+.work-card:where(:hover, :focus-within) .work-card__play {
+  transform: translateY(-2px);
+  opacity: 1;
+}
+
+.work-card__body {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px 20px;
+}
+
+.work-card__title {
+  font-size: clamp(1.1rem, 1.8vw, 1.3rem);
+  font-weight: 700;
+  letter-spacing: 0.2px;
+}
+
+.work-card__meta {
+  color: var(--work-text-dim);
+  line-height: 1.55;
+}
+
+.work-card__tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.work-tag {
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--work-border);
+  background: var(--work-surface);
+  color: var(--work-text-dim);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.work-card::before {
+  content: "";
+  position: absolute;
+  inset: -32% -32% auto;
+  height: 60%;
+  background: conic-gradient(from 210deg, rgba(214, 60, 255, 0.18), rgba(255, 122, 24, 0.16), rgba(214, 60, 255, 0.18));
+  filter: blur(28px) saturate(120%);
+  opacity: 0.3;
+  transition: opacity 0.28s var(--work-ease), transform 0.28s var(--work-ease);
+  pointer-events: none;
+}
+
+.work-card:where(:hover, :focus-within)::before {
+  opacity: 0.5;
+  transform: rotate(4deg) scale(1.05);
+}
+
+.work-card.is-fading-out {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+  pointer-events: none;
+}
+
+.work-card.is-activating {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+}
+
+.work-card.is-hidden {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filter-chip,
+  .work-card,
   .work-card__img,
-  .work-card__video{
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
+  .work-card__video,
+  .work-card__play {
+    transition: none !important;
+    animation: none !important;
   }
-  
-  /* Start with image visible */
-  .work-card__img{ opacity: 1; transition: opacity .3s var(--ease-out), transform .3s var(--ease-out); will-change: opacity, transform; }
-  .work-card__video{
-    opacity: 0;
-    transition: opacity .28s var(--ease-out), transform .28s var(--ease-out);
-    transform: scale(1.01);
-    filter: saturate(110%) contrast(105%) drop-shadow(0 8px 20px rgba(0,0,0,.3));
-  }
-  
-  /* On hover: fade in video */
-  .work-card:where(:hover,:focus-within) .work-card__video{
-    opacity: 1;
+
+  .work-card:where(:hover, :focus-within) {
     transform: none;
   }
-  .work-card:where(:hover,:focus-within) .work-card__img{
-    opacity: 0;
-    transform: scale(1.02);
+
+  .work-card.is-fading-out,
+  .work-card.is-activating {
+    transform: none;
   }
-  
-  /* Soft overlay + label */
-  .work-card__media::after{
-    content:"";
-    position:absolute; inset:0;
-    background: radial-gradient(120% 90% at 50% 10%, rgba(0,0,0,.0) 0%, rgba(0,0,0,.18) 80%);
-    pointer-events:none;
-  }
-  
-  /* Play glyph (for discoverability) */
-  .work-card__play{
-    position: absolute;
-    right: 10px; bottom: 10px;
-    z-index: 3;
-    height: 36px; width: 36px;
-    border-radius: 10px;
-    border: 1px solid var(--ss-border);
-    background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.02));
-    display: grid; place-items:center;
-    transition: transform .2s var(--ease-out), opacity .2s var(--ease-out);
-    opacity: .85;
-  }
-  .work-card:where(:hover,:focus-within) .work-card__play{ transform: translateY(-2px); opacity: 1; }
-  
-  /* ---------- Body ---------- */
-  .work-card__body{
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 10px 14px;
-    align-items: start;
-    padding: 12px 14px 14px 14px;
-  }
-  
-  .work-card__title{
-    font-weight: 700;
-    font-size: clamp(1.02rem, 1.4vw, 1.18rem);
-    letter-spacing: .2px;
-  }
-  
-  .work-card__meta{
-    color: var(--ss-text-dim);
-    font-size: .96rem;
-    grid-column: 1 / -1;
-  }
-  
-  .work-card__tags{
-    margin-top: 6px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    grid-column: 1 / -1;
-  }
-  
-  .work-tag{
-    padding: 5px 9px;
-    border-radius: 999px;
-    border: 1px solid var(--ss-border);
-    color: var(--ss-text-dim);
-    background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-    font-size: .80rem;
-    letter-spacing: .08em;
-    text-transform: uppercase;
-  }
-  
-  /* ---------- Link mask (card is clickable) ---------- */
-  .work-card__link{
-    position: absolute; inset: 0; z-index: 5;
-    border-radius: var(--ss-radius-xl);
-  }
-  .work-card__link:focus-visible{
-    outline: 2px solid rgba(177,76,255,.65);
-    outline-offset: 2px;
-    border-radius: 16px;
-  }
-  
-  /* ---------- Conic accent (subtle) ---------- */
-  .work-card::before{
-    content:"";
-    position:absolute; inset:-30% -30%;
-    background:
-      conic-gradient(from 210deg,
-        rgba(177,76,255,.12),
-        rgba(255,122,24,.10),
-        rgba(177,76,255,.12));
-    filter: blur(26px) saturate(120%);
-    opacity: .32;
-    transition: opacity .28s var(--ease-out), transform .28s var(--ease-out);
-    pointer-events: none;
-  }
-  .work-card:where(:hover,:focus-within)::before{
-    opacity: .5; transform: rotate(6deg) scale(1.02);
-  }
-  
-  /* ---------- Staggered reveal ---------- */
-  .work__grid .work-card{
-    opacity: 0;
-    transform: translateY(10px);
-    animation: work-in .45s var(--ease-out) forwards;
-  }
-  .work__grid .work-card:nth-child(1){ animation-delay: .02s; }
-  .work__grid .work-card:nth-child(2){ animation-delay: .06s; }
-  .work__grid .work-card:nth-child(3){ animation-delay: .10s; }
-  .work__grid .work-card:nth-child(4){ animation-delay: .14s; }
-  .work__grid .work-card:nth-child(5){ animation-delay: .18s; }
-  .work__grid .work-card:nth-child(6){ animation-delay: .22s; }
-  @keyframes work-in { to{ opacity:1; transform: translateY(0); } }
-  
-  /* ---------- Filter transitions (JS toggles .is-hidden) ---------- */
-  .work-card.is-hidden{
-    pointer-events: none;
-    opacity: 0;
-    transform: scale(.98);
-    transition: opacity .22s var(--ease-out), transform .22s var(--ease-out);
-  }
-  
-  /* ---------- Density options ---------- */
-  .work--compact .work-card__body{
-    padding: 10px 12px 12px 12px;
-  }
-  .work--compact .work-card__meta{
-    font-size: .9rem;
-  }
-  
-  /* ---------- Reduced motion ---------- */
-  @media (prefers-reduced-motion: reduce){
-    .work-card,
-    .work-card::before,
-    .work-card__img,
-    .work-card__video{
-      transition: none !important;
-      animation: none !important;
-      transform: none !important;
-    }
-  }
-  
-  /* ---------- Fine-tuning small screens ---------- */
-  @media (max-width: 420px){
-    .work-card__body{
-      grid-template-columns: 1fr;
-    }
-  }
-  
-  /* ---------- Optional: sticky filters on large screens ---------- */
-  /* Add .work--sticky-filters on the section to enable */
-  .work.work--sticky-filters .work__filters{
-    position: sticky;
-    top: 10px; /* adjust if header changes */
-    z-index: 5;
-    padding-top: 6px;
-    background: linear-gradient(180deg, rgba(0,0,0,.6), rgba(0,0,0,0));
-    -webkit-backdrop-filter: blur(4px);
-    backdrop-filter: blur(4px);
-    border-radius: 12px;
-  }
-  
-  /* ---------- Helper: badge-style count near filters ---------- */
-  .work__count{
-    margin-left: 2px;
-    color: var(--ss-text-dim);
-    font-size: .92rem;
-  }
-  
+}


### PR DESCRIPTION
## Summary
- rebuild the Launch Files portfolio grid with four case studies, hover videos, and category tags tied to new filters
- refresh the work section styling for filter chips, card overlays, and responsive layout states
- upgrade the portfolio hover module to handle keyboard navigation, smooth filtering, and controlled video playback

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1aea76b00832f8a800f6ff109c4a4